### PR TITLE
Remove double quotes from string value

### DIFF
--- a/lib/serverkit/resources/defaults.rb
+++ b/lib/serverkit/resources/defaults.rb
@@ -113,6 +113,8 @@ module Serverkit
               "(" + object.map { |element| generate(element) }.join(", ") + ")"
             when Hash
               "{" + object.map { |key, value| "#{generate(key)} = #{generate(value)}" }.join("; ") + "}"
+            when String
+              object
             when false
               generate(0)
             when true


### PR DESCRIPTION
Currently serverkit-defaults sets string values with `"`. 

For example,

``` yaml
  - type: defaults
    domain: com.apple.screencapture
    key: type
    value: jpg
```

will set `"jpg"` to `com.apple.screencapture`. But double quotes are not necessary.
